### PR TITLE
feat: add a switch for private and public modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ const apiKey = 'abcd-efgh-1234-5678';
 engageWebSdk.initialize({ apiKey });
 ```
 
+### Public and Private modes
+
+By default, the sdk is configured to operate with the public sdk, You can change this mode by passing the options: `mode: 'private'`, like this:
+```ts
+import { EngageWeb } from '@metacommerce-app/engage-js';
+
+const engageWebSdk = new EngageWeb();
+const apiKey = 'abcd-efgh-1234-5678';
+
+engageWebSdk.initialize({ apiKey, mode: 'private' });
+```
+
+
 ## Custom events
 
 ### Sending a custom event

--- a/src/Engage/Engage.ts
+++ b/src/Engage/Engage.ts
@@ -2,6 +2,7 @@ import { logger } from '../lib/logging';
 import { MissingApiKey } from '../lib/errors';
 import { IEngageSubComponent } from './EngageSubComponent';
 import { GenericEvent } from '../GenericEvent';
+import { Routes } from '../lib/routes';
 
 export class Engage {
   private apiKey?: string;
@@ -9,7 +10,7 @@ export class Engage {
 
   events!: IEngageSubComponent;
 
-  initialize(options: { apiKey: string; url?: string }): void {
+  initialize(options: { apiKey: string; url?: string; mode?: 'public' | 'private' }): void {
     if (!options.apiKey) {
       throw new MissingApiKey();
     }
@@ -19,7 +20,9 @@ export class Engage {
     this.url = options?.url ?? 'https://rest.metacommerce.app';
     logger.debug(`initialize: URL will be [ ${this.url} ]`);
     const engage_inbound_source = 'public-api';
+    const defautlMode = options?.mode ?? 'public';
+    const uri = defautlMode === 'public' ? Routes.PUBLIC_ACTIVITY_V1 : Routes.PRIVATE_ACTIVITY_V1;
 
-    this.events = new GenericEvent(this.url, this.apiKey, undefined, engage_inbound_source);
+    this.events = new GenericEvent(this.url, this.apiKey, uri, engage_inbound_source);
   }
 }

--- a/src/GenericEvent/GenericEvent.ts
+++ b/src/GenericEvent/GenericEvent.ts
@@ -25,8 +25,8 @@ export class GenericEvent implements IEngageSubComponent {
     this.url = new URL(`${host}/${this.uri}`);
     this.engage_inbound_source = engage_inbound_source;
 
-    this.user = new UserEvent(host, apiKey, uri);
-    this.wallet = new WalletEvent(host, apiKey, uri);
+    this.user = new UserEvent(host, apiKey, this.uri);
+    this.wallet = new WalletEvent(host, apiKey, this.uri);
   }
 
   async send(data: { [param: string]: string; type: string }): Promise<void> {


### PR DESCRIPTION
### Public and Private modes

By default, the sdk is configured to operate with the public sdk, You can change this mode by passing the options: `mode: 'private'`, like this:
```ts
import { EngageWeb } from '@metacommerce-app/engage-js';

const engageWebSdk = new EngageWeb();
const apiKey = 'abcd-efgh-1234-5678';

engageWebSdk.initialize({ apiKey, mode: 'private' });
```
